### PR TITLE
Fix broken primer link and audio URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ While no breaking changes were made to metadata schema, this version formalizes 
 ### Added
 
 * `10_COMMITS.md` — Cypherpop’s ethic layer formally committed as 10 executable principles
-* `CYPHERPOP_PROTOCOL_PRIMER.md` — replaces legacy manifesto with a modular philosophy + methodology doc
+* `PROTOCOL_PRIMER.md` — replaces legacy manifesto with a modular philosophy + methodology doc
 * `starter-kits/submit.md` — simple protocol-aligned guide for submitting track folders via pull request
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains the living documentation, templates, submission logic, 
 | File / Folder              | Purpose                                                                 |
 |----------------------------|-------------------------------------------------------------------------|
 | `10_COMMITS.md`            | The protocol’s ethic layer — 10 executable principles that define Cypherpop |
-| `CYPHERPOP_PROTOCOL_PRIMER.md` | The philosophy, process, and structure behind the protocol             |
+| `PROTOCOL_PRIMER.md` | The philosophy, process, and structure behind the protocol             |
 | `whitepaper.md`            | Deep dive into genre mechanics, aesthetic logic, and cultural roots      |
 | `cyphernary.md`            | Living glossary of key terms, symbolic logic, and protocol slang         |
 | `CHANGELOG.md`             | Version history of the protocol and architecture                         |
@@ -92,7 +92,7 @@ It was created to:
 - Build a forkable music standard where each track is versionable, ownable, remixable
 
 > To understand the ethic layer, read [`10_COMMITS.md`](./10_COMMITS.md)  
-> To understand the methodology, read [`CYPHERPOP_PROTOCOL_PRIMER.md`](./CYPHERPOP_PROTOCOL_PRIMER.md)
+> To understand the methodology, read [`PROTOCOL_PRIMER.md`](./PROTOCOL_PRIMER.md)
 
 ---
 

--- a/tracks/python/track.json
+++ b/tracks/python/track.json
@@ -1,5 +1,5 @@
 {
   "title": "Python",
   "version": "1.0.0 - dev",
-  "audio_url": "https://iihxjqkqnzfjoliiiehz.supabase.co/storage/v1/object/public/songs//Python%20Prac%201.mp3"
+  "audio_url": "https://iihxjqkqnzfjoliiiehz.supabase.co/storage/v1/object/public/songs/Python%20Prac%201.mp3"
 }


### PR DESCRIPTION
## Summary
- fix README references to PROTOCOL_PRIMER.md
- fix CHANGELOG to mention the correct primer filename
- remove double slash from audio URL in Python track

## Testing
- `git status --short`